### PR TITLE
Issue5

### DIFF
--- a/D4AD_Standardization/src/data/make_dataset.py
+++ b/D4AD_Standardization/src/data/make_dataset.py
@@ -7,15 +7,15 @@ from dotenv import find_dotenv, load_dotenv
 import pandas as pd
 import regex
 import re         # for field identification
-from utils.dataframe_manipulation import (
+from .utils.dataframe_manipulation import (
     replace_values,
     extract_values,
     split_on,
     write_out
 )
-from utils.abbreviation import multiple_mapper
-from utils.field_indicator import get_name_name1_descriptions_indices
-from utils.etpl_field_names import (
+from .utils.abbreviation import multiple_mapper
+from .utils.field_indicator import get_name_name1_descriptions_indices
+from .utils.etpl_field_names import (
     sql_etpl_field_names,
     sql_excel_field_map,
     labor_fields_to_internal,
@@ -54,8 +54,8 @@ def input_source(from_filepath=None, from_table=None, remap_field_names=False, s
         if file_extension in ('xls', 'xlsx'):
             df = pd.read_excel(from_filepath)
         if file_extension in ('csv'):
-            df = pd.read_csv(from_filepath)
-        
+            df = pd.read_csv(from_filepath, dtype=str)
+
         # We ignore case by lowercasing all column names (e.g. labor gives
         # different casing than sql, etc)
         df.columns = map(str.lower, df.columns)

--- a/D4AD_Standardization/src/data/utils/dataframe_manipulation.py
+++ b/D4AD_Standardization/src/data/utils/dataframe_manipulation.py
@@ -42,7 +42,6 @@ def split_on(the_series, split_on_string, n=1, get_nth_result=1):
 
 def write_out(the_df, write_path, content_is, root_path=ROOT_PATH,
               file_type="csv", remap_field_names=False, remapper=None):
-
     if remap_field_names:
         the_df =\
             the_df.rename(
@@ -54,19 +53,6 @@ def write_out(the_df, write_path, content_is, root_path=ROOT_PATH,
 
                 the_df.loc[make_false, field_name] = False
                 the_df.loc[~make_false, field_name] = True
-
-    # Pandas does not default to nullable integers on read_csv
-    # So we attempt type inference with the following
-    numeric_columns = df.select_dtypes(include='number')
-
-    for column in numeric_columns:
-        looks_like_integer = (df[column].fillna(1) % 1 == 0).all()
-        if looks_like_integer:
-            # then we have integers that were converted to float because
-            # we also have NaNs. We convert to special integer type
-            # that can handle NaNs, instead.
-            df[column] =\
-                df[column].astype('Int64')    
 
     if 'csv' == file_type:
         logger.info(f" ... writing to " + root_path + write_path + f"{content_is}.{file_type}")


### PR DESCRIPTION
* Pandas will run type inference over columns that coverts integer columns with NaNs to a float. This creates an issue when writing back out to .csv because .csv are typless and integer column is written as a float, with a .0 decimal. Solution is to read in dataframe as a `dtype=str`  