### PR TITLE
fix(issue 17)

### DIFF
--- a/D4AD_Standardization/data/external/label_mapper.csv
+++ b/D4AD_Standardization/data/external/label_mapper.csv
@@ -23,7 +23,6 @@ PC,Personal Computer
 CAD,Computer Aided Design
 GED,General Education Diploma
 SMAW,Shielded Metal Arc Welding
-AWS,American Welding Society
 ELEC,Electrical
 E,Electronic
 ACIS,Advanced Computer and Information Security


### PR DESCRIPTION
Removes AWS from abbreviation file so that Amazon Web Services and American Weilding Society dont' fight one another